### PR TITLE
add recommendation to use the gene fusion nomenclature for fusions

### DIFF
--- a/_bg-material/consultation/svd-wg007.md
+++ b/_bg-material/consultation/svd-wg007.md
@@ -4,6 +4,8 @@ title: SVD-WG007
 category: SVD-WG
 ---
 
+**NOTE:** We have updated our glossary and nomenclature to align with the [VICC Gene Fusion Specification](https://fusions.cancervariants.org/en/latest){:target="\_blank"} terminology, and clarify the distinction between chimeric transcript fusions (the biological concept) and adjoined transcript segments (a nomenclature structure). The "fusion transcript" concept adopted in this consultation was relabeled to "adjoined transcript segments" accordingly.
+
 ## Community Consultation
 
 ### Proposal SVD-WG007 (RNA fusion)

--- a/_bg-material/glossary.md
+++ b/_bg-material/glossary.md
@@ -222,7 +222,7 @@ Please note that this Glossary is **work in progress**. Do you encounter missing
     :   see also **frame**
 
 *	readthrough transcript
-	:	a chimeric transcript where the two (or more) genes involved are found on the same chromosomal region, on the same strand, and are typically adjacent to one another. Readthrough transcripts from genes that meet these criteria in reference (not rearranged) genome assemblies may be annotated differently than other chimeric transcripts (see `this note<https://fusions.cancervariants.org/en/latest/terminology.html#read-through-note>`_).
+	:	a chimeric transcript where the two (or more) genes involved can also be transcribed individually, and are found on the same chromosomal region, on the same strand, and typically adjacent to one another.
 
 *   regulatory fusion
     :   the novel interaction of a regulatory element brought into proximity of a partner gene by a genomic rearrangement, modulating gene product expression of the partner gene.

--- a/_bg-material/glossary.md
+++ b/_bg-material/glossary.md
@@ -222,7 +222,7 @@ Please note that this Glossary is **work in progress**. Do you encounter missing
     :   see also **frame**
 
 *	readthrough transcript
-	:	a chimeric transcript where the two (or more) genes involved can also be transcribed individually, and are found on the same chromosomal region, on the same strand, and typically adjacent to one another.
+	:	a chimeric transcript in which the two (or more) genes involved can also be transcribed individually, and are found on the same chromosomal region, on the same strand, and typically adjacent to one another.
 
 *   regulatory fusion
     :   the novel interaction of a regulatory element brought into proximity of a partner gene by a genomic rearrangement, modulating gene product expression of the partner gene.

--- a/_bg-material/glossary.md
+++ b/_bg-material/glossary.md
@@ -27,7 +27,7 @@ Please note that this Glossary is **work in progress**. Do you encounter missing
     :   first nucleotide of a transcript (5' end) to which a specially altered nucleotide is added.
 
 *   break point
-    :   the site where two sequences which are in different positions in the reference sequence are joined as a consequence of genomic rearrangement (Structural Variant)
+    :   the site where two sequences which are in different positions in the reference sequence are joined as a consequence of genomic rearrangement
 
 *   cDNA
     :   cDNA, "copy DNA" or "complementary DNA", is the DNA copy of a single stranded RNA molecule synthesized using the enzyme reverse transcriptase ([Wikipedia](https://en.wikipedia.org/wiki/Complementary_DNA){:target="\_blank"}, [MESH](https://www.ncbi.nlm.nih.gov/mesh/68018076){:target="\_blank"}).
@@ -35,6 +35,9 @@ Please note that this Glossary is **work in progress**. Do you encounter missing
 
 *   CDS
     :   coding DNA sequence, a sequence translated in to an amino acid sequence (protein).
+
+*   chimeric transcript
+    :   a transcript (RNA molecule) composed of transcript segments from two or more genes.
 
 *   chimerism
     :   the occurrence in one individual of two or more cell populations, derived from different zygotes, with different sequences (based on [MESH](http://www.ncbi.nlm.nih.gov/mesh?term=chimerism){:target="\_blank"}). Opposite of mosaicism.
@@ -103,12 +106,15 @@ Please note that this Glossary is **work in progress**. Do you encounter missing
 
 *   frame shift
     :   a sequence change between the translation initiation (start) and termination (stop) codon where, compared to a reference sequence, translation shifts to another reading frame ([_protein_](/recommendations/protein/variant/frameshift/))
-    
-*   fusion transcript
-    :   a transcript (RNA molecule) which consist of parts of transcripts from two or more genes, resulting from a translocation, deletion, or inversion.
+
+*   gene fusion
+    :   the joining of two or more genes resulting in a chimeric transcript and/or a novel interaction between a rearranged regulatory element with the expressed product of a partner gene (a regulatory fusion).
+
+*   genomic rearrangement
+    :   see *Structural Variant (SV)*
 
 *   haplotype
-    :   contiguous set of genetic variants that are co-located on one chromosome (molecule) and are inherited from the same parent
+    :   contiguous set of genetic variants that are co-located on one chromosome (molecule) and are inherited from the same parent.
 
 *   hemizygous
     :   an individual having **only one allele** at a given locus, either because the allele is absent (X and Y chromosome in males) or lost (deleted) (based on [MESH](http://www.ncbi.nlm.nih.gov/mesh?term=hemizygous){:target="\_blank"}).
@@ -216,7 +222,10 @@ Please note that this Glossary is **work in progress**. Do you encounter missing
     :   see also **frame**
 
 *	readthrough transcript
-	:	a transcript (RNA molecule) formed via the splicing of exons from more than one distinct gene. The two (or more) genes involved are found on the same chromosomal region, on the same strand, and are typically adjacent to one another.
+	:	a chimeric transcript where the two (or more) genes involved are found on the same chromosomal region, on the same strand, and are typically adjacent to one another.
+
+*   regulatory fusion
+    :   the novel interaction of a regulatory element brought into proximity of a partner gene by a genomic rearrangement, modulating gene product expression of the partner gene.
 
 *   repeated sequence
     :   **HGVS**: a sequence where, compared to a reference sequence, a segment of one or more nucleotides (the repeat unit) is present several times, one after the other.
@@ -260,6 +269,9 @@ Please note that this Glossary is **work in progress**. Do you encounter missing
 
 *   trans
     :   two variants are **"in trans"** when they are on different alleles (DNA molecules, chromosomes).
+
+*   transcript segment
+    :   a representation of a segment of transcribed sequence denoted by a 5’ and 3’ boundary.
     
 *   transition
     :   a nucleotide variant changing a purine nucleotide to another purine nucleotide (A < > G), or a pyrimidine nucleotide to another pyrimidine nucleotide (C < > T).

--- a/_bg-material/glossary.md
+++ b/_bg-material/glossary.md
@@ -222,7 +222,7 @@ Please note that this Glossary is **work in progress**. Do you encounter missing
     :   see also **frame**
 
 *	readthrough transcript
-	:	a chimeric transcript where the two (or more) genes involved are found on the same chromosomal region, on the same strand, and are typically adjacent to one another.
+	:	a chimeric transcript where the two (or more) genes involved are found on the same chromosomal region, on the same strand, and are typically adjacent to one another. Readthrough transcripts from genes that meet these criteria in reference (not rearranged) genome assemblies may be annotated differently than other chimeric transcripts (see `this note<https://fusions.cancervariants.org/en/latest/terminology.html#read-through-note>`_).
 
 *   regulatory fusion
     :   the novel interaction of a regulatory element brought into proximity of a partner gene by a genomic rearrangement, modulating gene product expression of the partner gene.

--- a/_recommendations/RNA/variant/description/delins-desc.md
+++ b/_recommendations/RNA/variant/description/delins-desc.md
@@ -22,9 +22,3 @@ Format:   **"prefix""position(s)\_deleted""delins""inserted_sequence"**,  e.g. r
 	*	exception: two variants separated by one nucleotide, together affecting one amino acid, should be described as a "delins" (e.g. r.142\_144delinsugg p.(Arg48Trp)).
 	:	**_NOTE:_**	this prevents tools predicting the consequences of a variant to make conflicting and incorrect predictions of two different substitutions at one position
 	*	**conversions**, a sequence change where a range of nucleotides are replaced by a sequence from elsewhere in the genome, are described as a “delins”. The previous format “con” is no longer used (see [_Community Consultation SVD-WG009)_](/bg-material/consultation/svd-wg009/)).
-*	Chimeric transcripts from gene fusions represent a special case of deletion-insertion variant. The fusion junction is described using **"::"**.
-	:	**_NOTE:_**	to avoid confusion, HGVS recommends following the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} and the [VICC Gene Fusion Specification](https://fusions.cancervariants.org/en/latest){:target="\_blank"} nomenclature to describe products of gene fusions
-    *   The HGNC recommendations include using a GENESYMBOL1::GENESYMBOL2 syntax for gene-level fusion descriptions, and GENESYMBOL1-GENESYMBOL2 syntax for read-through transcripts
-    *   The VICC nomenclature extends the HGNC recommendations to include a terminology, information model, and nomenclature for gene-level and exon-level representation, with components for disambiguating regulatory fusions from chimeric transcript fusions
-    *   HGVS also recommends the use of [adjoined transcript segments](/recommendations/RNA/variant/splicing/) for precise and unambiguous characterization of chimeric transcripts at the sequence level
-*	for all descriptions the **most 3' position** possible of the reference sequence is arbitrarily assigned to have been changed (**3'rule**)

--- a/_recommendations/RNA/variant/description/delins-desc.md
+++ b/_recommendations/RNA/variant/description/delins-desc.md
@@ -22,6 +22,9 @@ Format:   **"prefix""position(s)\_deleted""delins""inserted_sequence"**,  e.g. r
 	*	exception: two variants separated by one nucleotide, together affecting one amino acid, should be described as a "delins" (e.g. r.142\_144delinsugg p.(Arg48Trp)).
 	:	**_NOTE:_**	this prevents tools predicting the consequences of a variant to make conflicting and incorrect predictions of two different substitutions at one position
 	*	**conversions**, a sequence change where a range of nucleotides are replaced by a sequence from elsewhere in the genome, are described as a “delins”. The previous format “con” is no longer used (see [_Community Consultation SVD-WG009)_](/bg-material/consultation/svd-wg009/)).
-*	RNA-fusion transcripts represent a special case of deletion-insertion variant. The fusion break point is described using **"::"**
-	:	**_NOTE:_**	to avoid confusion, HGVS recommends to follow the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} to describe products of gene translocations or fusions (format GENESYMBOL1::GENESYMBOL2) and readthrough transcripts (format GENESYMBOL1-GENESYMBOL2)
+*	Chimeric transcripts from gene fusions represent a special case of deletion-insertion variant. The fusion junction is described using **"::"**.
+	:	**_NOTE:_**	to avoid confusion, HGVS recommends following the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} and the [VICC Gene Fusion Specification](https://fusions.cancervariants.org/en/latest){:target="\_blank"} nomenclature to describe products of gene fusions
+    *   The HGNC recommendations include using a GENESYMBOL1::GENESYMBOL2 syntax for gene-level fusion descriptions, and GENESYMBOL1-GENESYMBOL2 syntax for read-through transcripts
+    *   The VICC nomenclature extends the HGNC recommendations to include a terminology, information model, and nomenclature for gene-level and exon-level representation, with components for disambiguating regulatory fusions from chimeric transcript fusions
+    *   HGVS also recommends the use of [adjoined transcript segments](/recommendations/RNA/variant/splicing/) for precise and unambiguous characterization of chimeric transcripts at the sequence level
 *	for all descriptions the **most 3' position** possible of the reference sequence is arbitrarily assigned to have been changed (**3'rule**)

--- a/_recommendations/RNA/variant/description/splicing-desc.md
+++ b/_recommendations/RNA/variant/description/splicing-desc.md
@@ -4,7 +4,7 @@ title: splicing
 category: description
 ---
 
-Variants affecting RNA splicing result in either a [_deletion_](/recommendations/RNA/variant/deletion/) or [_insertion_](/recommendations/RNA/variant/insertion/) on the RNA level and should be described as such.
+Variants affecting RNA splicing result in either a [_deletion_](/recommendations/RNA/variant/deletion/) or [_insertion_](/recommendations/RNA/variant/insertion/) on the RNA level and should be described as such. Recommendations on representing chimeric transcripts formed by gene fusions are discussed in the Note below.
 
 ---
 
@@ -12,3 +12,7 @@ Variants affecting RNA splicing result in either a [_deletion_](/recommendations
 
 *	all variants **should be** described at the DNA level, descriptions at the RNA and/or protein level may be given in addition
 * a "," (comma) is used to separate different transcripts/proteins derived from one allele; r.[123a>u,122_154del]
+* HGVS recommends following the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} and the [VICC Gene Fusion Specification](https://fusions.cancervariants.org/en/latest){:target="\_blank"} nomenclature to describe products of gene fusions
+    *   The HGNC recommendations include using a GENESYMBOL1::GENESYMBOL2 syntax for gene-level fusion descriptions, and GENESYMBOL1-GENESYMBOL2 syntax for read-through transcripts
+    *   The VICC nomenclature extends the HGNC recommendations to include a terminology, information model, and nomenclature for gene-level and exon-level representation, with components for disambiguating regulatory fusions from chimeric transcript fusions
+    *   HGVS also recommends the use of adjoined transcript segments (see examples) for precise and unambiguous characterization of chimeric transcripts at the sequence level

--- a/_recommendations/RNA/variant/example/delins-eg.md
+++ b/_recommendations/RNA/variant/example/delins-eg.md
@@ -20,11 +20,3 @@ category: example
 	:	conversion replacing nucleotides r.414 to r.1655 with nucleotides 409 to 1649 as found in the genomic reference sequence AC096506.5
 	*	r.1401\_1446delins[NR\_002570.3:r.1513\_1558]
 	:	conversion in exon 9 of the CYP2D6 gene replacing exon 9 nucleotides r.1401 to r.1446 with those of the 3' flanking CYP2D7P1 gene, nucleotides r.1513 to r.1558
-*	RNA fusion transcripts (based on [_SVD-WG007_](/bg-material/consultation/svd-wg007/))
-	*	translocation fusion
-	:	 NM\_152263.2:r.-115\_775::NM_002609.3:r.1580\_\*1924 describes a TPM3::PDGFRB fusion transcript where nucleotides r.-115 to r.775 (reference transcript NM\_152263.2, TPM3 gene) are coupled to nucleotides r.1580 to r.\*1924 (reference transcript NM\_002609.3, PDGFRB gene)
-	*	**deletion fusion**
-		*	NM\_002354.2:r.-358\_555::NM\_000251.2:r.212\_\*279
-		:	describes an EPCAM::MSH2 fusion transcript where nucleotides r.-358 to r.555 (reference transcript NM\_002354.2, EPCAM gene) are coupled to nucleotides r.212 to r.\*279 (reference transcript NM\_000251.2, MSH2 gene)
-		*	NM\_002354.2:r.?\_555::guaugauuuuuuaataa::NM\_000251.2:r.212\_?
-		:	describes an EPCAM::MSH2 fusion transcript where only the fusion break point has been characterised, showing the insertion of a 17 nucletoide sequence (guaugauuuuuuaataa) between two fusion transcripts

--- a/_recommendations/RNA/variant/example/splicing-eg.md
+++ b/_recommendations/RNA/variant/example/splicing-eg.md
@@ -34,7 +34,7 @@ category: example
 	*	NC\_000023.11(NM\_004006.2):r.649\_650ins650-1400\_650-1268
 	:	as a consequence of an intron 7 variant (c.650-1401T>G) a new exon is created and its sequence (positions 650-1400 to 650-1268) is inserted in the transcript
 	:	alternative description LRG\_199t1:r.649\_650ins650-1400\_650-1268	
-*	**fusion transcript** (based on [_SVD-WG007_](/bg-material/consultation/svd-wg007/)) 
+*	**adjoined transcript segments** (based on [_SVD-WG007_](/bg-material/consultation/svd-wg007/) and subsequent alignment with the [VICC Gene Fusion Specification](https://fusions.cancervariants.org/en/latest){:target="\_blank"} terminology) 
 	*	NM\_002354.2:r.-358\_555::NM\_000251.2:r.212\_\*279
 	:	describes an EPCAM::MSH2 fusion transcript where nucleotides r.-358 to r.555 (EPCAM gene, reference transcript NM\_002354.2) are spliced to nucleotides r.212 to r.\*279 (MSH2 gene, reference transcript NM\_000251.2)
 *	**uncertain** (RNA not analysed)

--- a/_recommendations/general.md
+++ b/_recommendations/general.md
@@ -53,7 +53,8 @@ Make sure you have also seen the ([_Basics_](/bg-material/basics/), explaining t
 *	only **approved** [HGNC gene symbols](http://www.genenames.org){:target="\_blank"} should be used to describe genes
 	:	**_NOTE:_**	to avoid confusion, HGVS recommends to follow the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} to use _**italics**_ to denote genes
 	:	**_NOTE:_**	for protein nomenclature see the [_International Protein Nomenclature Guidelines_](https://www.ncbi.nlm.nih.gov/genome/doc/internatprot_nomenguide/){:target="\_blank"}, written with the involvement of the HGNC
-* for the description of gene fusions, see the [_VICC Gene Fusion Nomenclature_](https://fusions.cancervariants.org/en/latest){:target="\_blank"}, which incorporates the recommendations of the HGNC, ISCN, and HVNC for gene fusion designations.
+**_NOTE:_**	to avoid confusion, HGVS recommends following the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} to use _**italics**_ to denote genes 
+* HGVS recommends following the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} and the [_VICC Gene Fusion Nomenclature_](https://fusions.cancervariants.org/en/latest){:target="\_blank"} to describe products of gene fusions
 
 * * *
 <a name="characters"></a>

--- a/_recommendations/general.md
+++ b/_recommendations/general.md
@@ -53,10 +53,10 @@ Make sure you have also seen the ([_Basics_](/bg-material/basics/), explaining t
 *	only **approved** [HGNC gene symbols](http://www.genenames.org){:target="\_blank"} should be used to describe genes
 	:	**_NOTE:_**	to avoid confusion, HGVS recommends to follow the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} to use _**italics**_ to denote genes
 	:	**_NOTE:_**	for protein nomenclature see the [_International Protein Nomenclature Guidelines_](https://www.ncbi.nlm.nih.gov/genome/doc/internatprot_nomenguide/){:target="\_blank"}, written with the involvement of the HGNC
-* HGVS recommends following the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} and the [_VICC Gene Fusion Nomenclature_](https://fusions.cancervariants.org/en/latest){:target="\_blank"} to describe products of gene fusions
+* HGVS recommends following the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} and the [VICC Gene Fusion Nomenclature](https://fusions.cancervariants.org/en/latest){:target="\_blank"} to describe products of gene fusions
     *   The HGNC recommendations include using a GENESYMBOL1::GENESYMBOL2 syntax for gene-level fusion descriptions, and GENESYMBOL1-GENESYMBOL2 syntax for read-through transcripts
     *   The VICC nomenclature extends the HGNC recommendations to include a terminology, information model, and nomenclature for gene-level and exon-level representation, with components for disambiguating regulatory fusions from chimeric transcript fusions
-  	*   HGVS also recommends the use of [adjoined transcript segments](RNA/variant/splicing.html) for precise and unambiguous characterization of chimeric transcripts at the sequence level
+    *   HGVS also recommends the use of [adjoined transcript segments](../RNA/variant/splicing/) for precise and unambiguous characterization of chimeric transcripts at the sequence level
 
 * * *
 <a name="characters"></a>

--- a/_recommendations/general.md
+++ b/_recommendations/general.md
@@ -56,7 +56,7 @@ Make sure you have also seen the ([_Basics_](/bg-material/basics/), explaining t
 * HGVS recommends following the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} and the [VICC Gene Fusion Specification](https://fusions.cancervariants.org/en/latest){:target="\_blank"} nomenclature to describe products of gene fusions
     *   The HGNC recommendations include using a GENESYMBOL1::GENESYMBOL2 syntax for gene-level fusion descriptions, and GENESYMBOL1-GENESYMBOL2 syntax for read-through transcripts
     *   The VICC nomenclature extends the HGNC recommendations to include a terminology, information model, and nomenclature for gene-level and exon-level representation, with components for disambiguating regulatory fusions from chimeric transcript fusions
-    *   HGVS also recommends the use of [adjoined transcript segments](../RNA/variant/splicing/) for precise and unambiguous characterization of chimeric transcripts at the sequence level
+    *   HGVS also recommends the use of [adjoined transcript segments](/recommendations/RNA/variant/splicing/) for precise and unambiguous characterization of chimeric transcripts at the sequence level
 
 * * *
 <a name="characters"></a>

--- a/_recommendations/general.md
+++ b/_recommendations/general.md
@@ -54,6 +54,7 @@ Make sure you have also seen the ([_Basics_](/bg-material/basics/), explaining t
 	:	**_NOTE:_**	to avoid confusion, HGVS recommends to follow the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} to use _**italics**_ to denote genes
 	:	**_NOTE:_**	for protein nomenclature see the [_International Protein Nomenclature Guidelines_](https://www.ncbi.nlm.nih.gov/genome/doc/internatprot_nomenguide/){:target="\_blank"}, written with the involvement of the HGNC
 * HGVS recommends following the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} and the [_VICC Gene Fusion Nomenclature_](https://fusions.cancervariants.org/en/latest){:target="\_blank"} to describe products of gene fusions
+  	*   HGVS also recommends the use of [adjoined transcript segments](RNA/variant/splicing.html) for precise and unambiguous characterization of chimeric transcripts at the sequence level
 
 * * *
 <a name="characters"></a>

--- a/_recommendations/general.md
+++ b/_recommendations/general.md
@@ -53,7 +53,6 @@ Make sure you have also seen the ([_Basics_](/bg-material/basics/), explaining t
 *	only **approved** [HGNC gene symbols](http://www.genenames.org){:target="\_blank"} should be used to describe genes
 	:	**_NOTE:_**	to avoid confusion, HGVS recommends to follow the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} to use _**italics**_ to denote genes
 	:	**_NOTE:_**	for protein nomenclature see the [_International Protein Nomenclature Guidelines_](https://www.ncbi.nlm.nih.gov/genome/doc/internatprot_nomenguide/){:target="\_blank"}, written with the involvement of the HGNC
-**_NOTE:_**	to avoid confusion, HGVS recommends following the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} to use _**italics**_ to denote genes 
 * HGVS recommends following the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} and the [_VICC Gene Fusion Nomenclature_](https://fusions.cancervariants.org/en/latest){:target="\_blank"} to describe products of gene fusions
 
 * * *

--- a/_recommendations/general.md
+++ b/_recommendations/general.md
@@ -8,7 +8,7 @@ order: 1
 
 Since references to web sites are not yet acknowledged as citations, please mention Den Dunnen et al. (2016) [HGVS recommendations for the description of sequence variants: 2016 update. Hum.Mutat. 25: 37: 564-569](http://onlinelibrary.wiley.com/doi/10.1002/humu.22981/pdf){:target="\_blank"} when referring to these pages. Note that although the examples on these pages mainly give examples for human (_Homo sapiens_), the recommendations can be applied to **all species**.
 
-Make sure you have also seen the ([_Basics_](/bg-material/basics/), explaining the **history** of these recommendations, the process of making **changes**, the **versioning** of the recommendations and important remarks on **terminology**. 
+Make sure you have also seen the ([_Basics_](/bg-material/basics/), explaining the **history** of these recommendations, the process of making **changes**, the **versioning** of the recommendations and important remarks on **terminology**.
 
 * * *
 
@@ -16,7 +16,7 @@ Make sure you have also seen the ([_Basics_](/bg-material/basics/), explaining t
 
 *	all variants should be described at the most basic level, **the DNA level**. Descriptions at the RNA and/or protein level may be given in addition.
 	*	descriptions should make clear whether the change was **experimentally determined** or **theoretically deduced** by giving predicted consequences in parentheses
-	*	descriptions at RNA/protein level should describe the changes observed on that level (RNA/protein) and not try to incorporate any knowledge regarding the change at DNA-level (see Questions below)	
+	*	descriptions at RNA/protein level should describe the changes observed on that level (RNA/protein) and not try to incorporate any knowledge regarding the change at DNA-level (see Questions below)
 *	all variants should be described in relation to an accepted **reference sequence** ([_see Reference Sequences_](/bg-material/refseq)).
 	*	the reference sequence file used should be **public and clearly described**, e.g. NC\_000023.10, LRG\_199, NG\_012232.1, NM\_004006.2, LRG\_199t1, NR\_002196.1, NP\_003997.1, etc. ([_see Reference Sequences_](/bg-material/refseq))
 	*	the reference sequence used must contain the residue(s) described to be changed.
@@ -24,9 +24,9 @@ Make sure you have also seen the ([_Basics_](/bg-material/basics/), explaining t
 		*	for human the recommended reference is based on genome build GRCh38/hg38, e.g. NC_000023.11 for the chromosome X
 		*	when variants are reported in relation to a transcript, the preferred reference sequence is the reference suggested by the MANE project (see [Ensembl](http://tark.ensembl.org/web/mane_project/){:target="\_blank"} or [NCBI](https://www.ncbi.nlm.nih.gov/refseq/MANE/){:target="\_blank"})
 		:	**_NOTE:_**	while [Locus Reference Genomic (LRG)](http://www.lrg-sequence.org){:target="\_blank"} reference sequences are still acceptable, new LRG’s are no longer generated and RefSeq or Ensembl transcripts specified by the MANE project are preferred for all genes where available to help standardize clinical reporting.
-	*	the reference sequence used must contain the residue(s) described to be changed. 
+	*	the reference sequence used must contain the residue(s) described to be changed.
 	*	a **letter prefix** is mandatory to indicate the type of reference sequence used. Accepted prefixes are;
-		*	"**c.**" for a coding DNA reference sequence	
+		*	"**c.**" for a coding DNA reference sequence
 		*	"**g.**" for a linear genomic reference sequence
 		*	"**m.**" for a mitochondrial DNA reference sequence
 		*	"**n.**" for a non-coding DNA reference sequence
@@ -44,15 +44,16 @@ Make sure you have also seen the ([_Basics_](/bg-material/basics/), explaining t
 *	descriptions at DNA, RNA and protein level are clearly different:
 	*	**DNA-level** 123456A>T ([_see Details_](/recommendations/DNA)): number(s) referring to the nucleotide(s) affected, nucleotides in CAPITALS using [_IUPAC-IUBMB assigned nucleotide symbols_](http://www.qmul.ac.uk/sbcs/iubmb/misc/naseq.html#500){:target="\_blank"}
 	*	**RNA-level** 76a>u ([_see Details_](/recommendations/RNA)): number(s) referring to the nucleotide(s) affected, nucleotides in lower case using [IUPAC-IUBMB assigned nucleotide symbols](http://www.qmul.ac.uk/sbcs/iubmb/misc/naseq.html#500){:target="\_blank"}
-	*	**protein level** Lys76Asn ([_see Details_](/recommendations/protein)): the amino acid(s) affected in three- or one-letter code followed by a number [IUPAC-IUBMB assigned amino acid symbols](http://www.iupac.org/publications/pac/1984/pdf/5605x0595.pdf){:target="\_blank"} 
+	*	**protein level** Lys76Asn ([_see Details_](/recommendations/protein)): the amino acid(s) affected in three- or one-letter code followed by a number [IUPAC-IUBMB assigned amino acid symbols](http://www.iupac.org/publications/pac/1984/pdf/5605x0595.pdf){:target="\_blank"}
 		*	**three-letter** amino acid code is preferred ([_see Standards_](/bg-material/standards/#aacode))
 		*	the **"*"** can be used to indicate the translation stop codon in both one- and three-letter amino acid code descriptions
 *	**prioritisation**: when a description is possible according to several types, the preferred description is: (1) substitution, (2) deletion, (3) inversion, (4) duplication, (5) insertion
 	* 	when a variant can be described as a duplication or an insertion, prioritisation determines it should be described as a duplication
 	*	descriptions removing part of a reference sequence replacing it with part of the same sequence are not allowed (e.g. NM\_004006.2:c.[762_768del;767_774dup])
 *	only **approved** [HGNC gene symbols](http://www.genenames.org){:target="\_blank"} should be used to describe genes
-	:	**_NOTE:_**	to avoid confusion, HGVS recommends to follow the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} to use _**italics**_ to denote genes and to describe products of gene translocations or fusions (format GENESYMBOL1::GENESYMBOL2) and readthrough transcripts (format GENESYMBOL1-GENESYMBOL2)
+	:	**_NOTE:_**	to avoid confusion, HGVS recommends to follow the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} to use _**italics**_ to denote genes
 	:	**_NOTE:_**	for protein nomenclature see the [_International Protein Nomenclature Guidelines_](https://www.ncbi.nlm.nih.gov/genome/doc/internatprot_nomenguide/){:target="\_blank"}, written with the involvement of the HGNC
+* for the description of gene fusions at the gene or exon level, see the [_VICC Gene Fusion Nomenclature_](https://fusions.cancervariants.org/en/latest){:target="\_blank"}, written with the involvement of the HGNC, HVNC, and ISCN.
 
 * * *
 <a name="characters"></a>
@@ -63,9 +64,9 @@ In HGVS nomenclature some **characters** have a **specific meaning**
 
 *	"**<font color="red">+</font>**" (plus) is used in [_nucleotide numbering_](/bg-material/numbering); c.123+45A>G
 *	"**<font color="red">-</font>**" (minus) is used in [_nucleotide numbering_](/bg-material/numbering); c.124-56C>T
-*	"**<font color="red">*</font>**" (asterisk) is used in [_nucleotide numbering_](/bg-material/numbering) and to indicate a translation termination (stop) codon ([_see Standards_](/bg-material/standards#RNAcode)); c.\*32G>A and p.Trp41\* 
+*	"**<font color="red">*</font>**" (asterisk) is used in [_nucleotide numbering_](/bg-material/numbering) and to indicate a translation termination (stop) codon ([_see Standards_](/bg-material/standards#RNAcode)); c.\*32G>A and p.Trp41\*
 *	"**<font color="red">_</font>**" (underscore) is used to indicate a range; g.12345\_12678del
-*	"**<font color="red">[ ]</font>**" (square brackets) are used for alleles (see [_DNA_](/recommendations/DNA/variant/alleles), [_RNA_](/recommendations/RNA/variant/alleles), [_protein_](/recommendations/protein/variant/alleles)), which includes multiple inserted sequences at one position and insertions from a second reference sequence 
+*	"**<font color="red">[ ]</font>**" (square brackets) are used for alleles (see [_DNA_](/recommendations/DNA/variant/alleles), [_RNA_](/recommendations/RNA/variant/alleles), [_protein_](/recommendations/protein/variant/alleles)), which includes multiple inserted sequences at one position and insertions from a second reference sequence
 	*	"**<font color="red">;</font>**" (semi colon) is used to separate variants and alleles; g.[123456A>G;345678G>C] or g.[123456A>G];[345678G>C]
 	*	"**<font color="red">,</font>**" (comma) is used to separate different transcripts/proteins derived from one allele; r.[123a>u, 122\_154del]
 	*	NC\_000002.11:g.48031621\_48031622ins[TAT;48026961\_48027223;GGC]
@@ -90,11 +91,11 @@ In HGVS nomenclature some **characters** have a **specific meaning**
 Specific abbreviations are used to describe different variant types.
 
 *	"**<font color="red">&gt;</font>**" (greater then) indicates a **substitution** (DNA and RNA level); g.123456G>A, r.123c>u (see [_DNA_](/recommendations/DNA/variant/substitution), [_RNA_](/recommendations/RNA/variant/substitution))
-	*	a substitution at the protein level is described as p.Ser321Arg (see [_protein_](/recommendations/protein/variant/substitution)) 
+	*	a substitution at the protein level is described as p.Ser321Arg (see [_protein_](/recommendations/protein/variant/substitution))
 *	"**<font color="red">del</font>**" indicates a **deletion**; c.76delA (see [_DNA_](/recommendations/DNA/variant/deletion), [_RNA_](/recommendations/RNA/variant/deletion), [_protein_](/recommendations/protein/variant/deletion))
 *	"**<font color="red">dup</font>**" indicates a **duplication**; c.76dupA (see [_DNA_](/recommendations/DNA/variant/duplication), [_RNA_](/recommendations/RNA/variant/duplication), [_protein_](/recommendations/protein/variant/duplication))
 *	"**<font color="red">ins</font>**" indicates an **insertion**; c.76\_77insG (see [_DNA_](/recommendations/DNA/variant/insertion), [_RNA_](/recommendations/RNA/variant/insertion), [_protein_](/recommendations/protein/variant/insertion))
-	*	duplicating insertions are described as duplications, not as insertions	
+	*	duplicating insertions are described as duplications, not as insertions
 *	"**<font color="red">inv</font>**" indicates an **inversion**; c.76\_83inv (see [_DNA_](/recommendations/DNA/variant/inversion), [_RNA_](/recommendations/RNA/variant/inversion)). Not used at protein level, usually described as [_"delins"_](/recommendations/protein/variant/delins/)
 *	"**<font color="red">fs</font>**" indicates a **frame shift**; p.Arg456GlyfsTer17 (or p.Arg456Glyfs*17, [_see Frame shifts_](/recommendations/protein/variant/frameshift))
 *	"**<font color="red">ext</font>**" indicates an **extension**; p.Met1**<font color="red">ext</font>**-5 ([_see Extension_](/recommendations/protein/variant/extension))
@@ -119,7 +120,7 @@ Specific abbreviations are used to describe different variant types.
 :	The sign used to indicate a range is "_" (underscore) and not a "-" (minus). The minus sign should only be used as a minus in the description of variants based on a coding DNA reference sequence. c.12-14del describes a deletion of nucleotide -14 in the intron directly preceding coding DNA nucleotide 12, **not** a deletion of nucleotides c.12 to c.14.
 
 *	Why is it recommended to use **three-letter amino acid code** to describe protein variants?
-:	Several amino acids start with the same initial letter (**<font color="red">A</font>**la, **<font color="red">A</font>**rg, **<font color="red">A</font>**sn, **<font color="red">A</font>**sp start with **<font color="red">A</font>**, **<font color="green">G</font>**ln, **<font color="green">G</font>**lu, **<font color="green">G</font>**ly with **<font color="green">G</font>**, **<font color="blue">L</font>**eu, **<font color="blue">L</font>**ys with **<font color="blue">L</font>**, **<font color="red">P</font>**he, **<font color="red">P</font>**ro with **<font color="red">P</font>** and **<font color="green">T</font>**hr, **<font color="green">T</font>**yr with **<font color="green">T</font>**) but in one-letter amino acid code this letter is used as abbreviation for only one. In practice this leads to many mistakes. It is therefore recommended to use three-letter amino acid code abbreviations. 
+:	Several amino acids start with the same initial letter (**<font color="red">A</font>**la, **<font color="red">A</font>**rg, **<font color="red">A</font>**sn, **<font color="red">A</font>**sp start with **<font color="red">A</font>**, **<font color="green">G</font>**ln, **<font color="green">G</font>**lu, **<font color="green">G</font>**ly with **<font color="green">G</font>**, **<font color="blue">L</font>**eu, **<font color="blue">L</font>**ys with **<font color="blue">L</font>**, **<font color="red">P</font>**he, **<font color="red">P</font>**ro with **<font color="red">P</font>** and **<font color="green">T</font>**hr, **<font color="green">T</font>**yr with **<font color="green">T</font>**) but in one-letter amino acid code this letter is used as abbreviation for only one. In practice this leads to many mistakes. It is therefore recommended to use three-letter amino acid code abbreviations.
 
 *	When I want to report a variant on DNA, RNA and protein level do I need to use a specific separator?
 	:	No, best is to report the variant using the format NC\_000023.11:g.32849790T>A NM\_004006.3:c.124A>T r.(124a>u) p.(Ser42Cys)
@@ -130,7 +131,7 @@ Specific abbreviations are used to describe different variant types.
 
 *	What do you mean with "variants should be described on the protein level and not incorporate knowledge regarding the change at the DNA-level"?
 	:	It means that protein variant descriptions should be derived from comparing the variant protein sequence with the reference protein sequence. Knowledge on the underlying change at the DNA level should not be used. E.g. when MetTrpSerSerSerHisAsp.. changes to MetTrpSerSer<b><font color="red">_</font></b>HisAsp.. this is described as p.Ser5del. The information that at the DNA level the change is ..ATGTGGTCCAGTTCCCACGAT.. to ..ATGTGGTCC<b><font color="red">_</font></b>TCCCACGAT.., so the codon for Ser4 is deleted, is not used; the description p.Ser4del is not correct.
-	
+
 *	Is it correct that when I apply **the 3'rule** for genes that are on the minus strand of a chromosome, the "g." and "c." variant descriptions differ regarding the nucleotide that I describe as deleted?
 	:	Yes, when a gene is on the minus strand of a chromosome (opposite transcriptional orientation) and the change is located in a repeated sequence (mono-, di-, tri-, etc. nucleotide stretches) the 3'rule has this as a consequence. When the chromosome sequence is -TGGGGCAT- and one of the G's is deleted (change to -TGGG_CAT-) the description based on chromosome coordinates is g.5delG. When the annotated coding DNA reference sequence is on the minus strand (ATGCCCCA) the description is c.7delC. Not only is the deleted nucleotide different (delG vs. delC), in fact the descriptions also point to another nucleotide, g.5 vs. g.2 (equivalent to c.7delC).
 

--- a/_recommendations/general.md
+++ b/_recommendations/general.md
@@ -53,7 +53,7 @@ Make sure you have also seen the ([_Basics_](/bg-material/basics/), explaining t
 *	only **approved** [HGNC gene symbols](http://www.genenames.org){:target="\_blank"} should be used to describe genes
 	:	**_NOTE:_**	to avoid confusion, HGVS recommends to follow the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} to use _**italics**_ to denote genes
 	:	**_NOTE:_**	for protein nomenclature see the [_International Protein Nomenclature Guidelines_](https://www.ncbi.nlm.nih.gov/genome/doc/internatprot_nomenguide/){:target="\_blank"}, written with the involvement of the HGNC
-* for the description of gene fusions at the gene or exon level, see the [_VICC Gene Fusion Nomenclature_](https://fusions.cancervariants.org/en/latest){:target="\_blank"}, which incorporates and extends recommendations of the HGNC for gene fusion and readthrough transcript designation.
+* for the description of gene fusions, see the [_VICC Gene Fusion Nomenclature_](https://fusions.cancervariants.org/en/latest){:target="\_blank"}, which incorporates the recommendations of the HGNC, ISCN, and HVNC for gene fusion designations.
 
 * * *
 <a name="characters"></a>

--- a/_recommendations/general.md
+++ b/_recommendations/general.md
@@ -54,6 +54,8 @@ Make sure you have also seen the ([_Basics_](/bg-material/basics/), explaining t
 	:	**_NOTE:_**	to avoid confusion, HGVS recommends to follow the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} to use _**italics**_ to denote genes
 	:	**_NOTE:_**	for protein nomenclature see the [_International Protein Nomenclature Guidelines_](https://www.ncbi.nlm.nih.gov/genome/doc/internatprot_nomenguide/){:target="\_blank"}, written with the involvement of the HGNC
 * HGVS recommends following the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} and the [_VICC Gene Fusion Nomenclature_](https://fusions.cancervariants.org/en/latest){:target="\_blank"} to describe products of gene fusions
+    *   The HGNC recommendations include using a GENESYMBOL1::GENESYMBOL2 syntax for gene-level fusion descriptions, and GENESYMBOL1-GENESYMBOL2 syntax for read-through transcripts
+    *   The VICC nomenclature extends the HGNC recommendations to include a terminology, information model, and nomenclature for gene-level and exon-level representation, with components for disambiguating regulatory fusions from chimeric transcript fusions
   	*   HGVS also recommends the use of [adjoined transcript segments](RNA/variant/splicing.html) for precise and unambiguous characterization of chimeric transcripts at the sequence level
 
 * * *

--- a/_recommendations/general.md
+++ b/_recommendations/general.md
@@ -53,7 +53,7 @@ Make sure you have also seen the ([_Basics_](/bg-material/basics/), explaining t
 *	only **approved** [HGNC gene symbols](http://www.genenames.org){:target="\_blank"} should be used to describe genes
 	:	**_NOTE:_**	to avoid confusion, HGVS recommends to follow the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} to use _**italics**_ to denote genes
 	:	**_NOTE:_**	for protein nomenclature see the [_International Protein Nomenclature Guidelines_](https://www.ncbi.nlm.nih.gov/genome/doc/internatprot_nomenguide/){:target="\_blank"}, written with the involvement of the HGNC
-* for the description of gene fusions at the gene or exon level, see the [_VICC Gene Fusion Nomenclature_](https://fusions.cancervariants.org/en/latest){:target="\_blank"}, written with the involvement of the HGNC, HVNC, and ISCN.
+* for the description of gene fusions at the gene or exon level, see the [_VICC Gene Fusion Nomenclature_](https://fusions.cancervariants.org/en/latest){:target="\_blank"}, which incorporates and extends recommendations of the HGNC for gene fusion and readthrough transcript designation.
 
 * * *
 <a name="characters"></a>

--- a/_recommendations/general.md
+++ b/_recommendations/general.md
@@ -53,7 +53,7 @@ Make sure you have also seen the ([_Basics_](/bg-material/basics/), explaining t
 *	only **approved** [HGNC gene symbols](http://www.genenames.org){:target="\_blank"} should be used to describe genes
 	:	**_NOTE:_**	to avoid confusion, HGVS recommends to follow the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} to use _**italics**_ to denote genes
 	:	**_NOTE:_**	for protein nomenclature see the [_International Protein Nomenclature Guidelines_](https://www.ncbi.nlm.nih.gov/genome/doc/internatprot_nomenguide/){:target="\_blank"}, written with the involvement of the HGNC
-* HGVS recommends following the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} and the [VICC Gene Fusion Nomenclature](https://fusions.cancervariants.org/en/latest){:target="\_blank"} to describe products of gene fusions
+* HGVS recommends following the [HGNC guidelines](https://www.genenames.org/about/guidelines/){:target="\_blank"} and the [VICC Gene Fusion Specification](https://fusions.cancervariants.org/en/latest){:target="\_blank"} nomenclature to describe products of gene fusions
     *   The HGNC recommendations include using a GENESYMBOL1::GENESYMBOL2 syntax for gene-level fusion descriptions, and GENESYMBOL1-GENESYMBOL2 syntax for read-through transcripts
     *   The VICC nomenclature extends the HGNC recommendations to include a terminology, information model, and nomenclature for gene-level and exon-level representation, with components for disambiguating regulatory fusions from chimeric transcript fusions
     *   HGVS also recommends the use of [adjoined transcript segments](../RNA/variant/splicing/) for precise and unambiguous characterization of chimeric transcripts at the sequence level


### PR DESCRIPTION
@jtdendunnen please see this draft language for referencing the VICC nomenclature following our last HVNC discussion.

NOTE: my code editor silently removed all trailing whitespace on this page, and that is also represented in this PR.