### PR TITLE
selectively sync VarNomen and archive sites before launch

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-varnomen.hgvs.org
+archive.hgvs-nomenclature.org

--- a/_layouts/default-md.html
+++ b/_layouts/default-md.html
@@ -1,27 +1,36 @@
 <!DOCTYPE html>
 <html>
 
-    {% include head.html %}
+{% include head.html %}
 
-    <body>
+<body>
 
-        {% include header.html %}
-            
-            {% if page.main %}
-                {{ content | markdownify }}
-            {% else %}
-                <div class="container">
-                    {% if page.last-modified %}
-                    <div class="last-modified pull-right">
-                        Last modified: {{ page.last-modified }}
-                    </div>
-                    {% endif %}
-                    {{ content | markdownify }}
-                </div>
-            {% endif %}
+    {% include header.html %}
 
-        {% include footer.html %}
+    <div class="banner">
+        <span style="font-size: larger; font-weight: bold">We've moved!
+            The HGVS Nomenclature is now at <a
+                href="https://hgvs-nomenclature.org/">https://hgvs-nomenclature.org/</a>.</span>
+        <br />
+        This site contains an archive of varnomen.hgvs.org and is no longer maintained.
+    </div>
 
-    </body>
+
+    {% if page.main %}
+    {{ content | markdownify }}
+    {% else %}
+    <div class="container">
+        {% if page.last-modified %}
+        <div class="last-modified pull-right">
+            Last modified: {{ page.last-modified }}
+        </div>
+        {% endif %}
+        {{ content | markdownify }}
+    </div>
+    {% endif %}
+
+    {% include footer.html %}
+
+</body>
 
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,27 +1,36 @@
 <!DOCTYPE html>
 <html>
 
-    {% include head.html %}
+{% include head.html %}
 
-    <body>
+<body>
 
-        {% include header.html %}
-            
-            {% if page.main %}
-                {{ content }}
-            {% else %}
-                <div class="container">
-                {% if page.last-modified %}
-                    <div class="last-modified pull-right">
-                        Last modified: {{ page.last-modified }}
-                    </div>
-                {% endif %}
-                    {{ content }}
-                </div>
-            {% endif %}
+    {% include header.html %}
 
-        {% include footer.html %}
+    <div class="banner">
+        <span style="font-size: larger; font-weight: bold">This site is obsolete.</span>
+        <br/>
+        The HGVS Nomenclature is now at <a
+        href="https://hgvs-nomenclature.org/">https://hgvs-nomenclature.org/</a>.
+        <br/>
+        This site contains an archive of varnomen.hgvs.org and is no longer maintained.
+    </div>
+    
+    {% if page.main %}
+    {{ content }}
+    {% else %}
+    <div class="container">
+        {% if page.last-modified %}
+        <div class="last-modified pull-right">
+            Last modified: {{ page.last-modified }}
+        </div>
+        {% endif %}
+        {{ content }}
+    </div>
+    {% endif %}
 
-    </body>
+    {% include footer.html %}
+
+</body>
 
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,10 +8,9 @@
     {% include header.html %}
 
     <div class="banner">
-        <span style="font-size: larger; font-weight: bold">This site is obsolete.</span>
-        <br/>
+        <span style="font-size: larger; font-weight: bold">We've moved! 
         The HGVS Nomenclature is now at <a
-        href="https://hgvs-nomenclature.org/">https://hgvs-nomenclature.org/</a>.
+        href="https://hgvs-nomenclature.org/">https://hgvs-nomenclature.org/</a>.</span>
         <br/>
         This site contains an archive of varnomen.hgvs.org and is no longer maintained.
     </div>

--- a/_layouts/recommendation.html
+++ b/_layouts/recommendation.html
@@ -1,26 +1,34 @@
 <!DOCTYPE html>
 <html>
 
-    {% include head.html %}
+{% include head.html %}
 
-    <body>
+<body>
 
-        {% include header.html %}
+    {% include header.html %}
 
-        <div class="container">
-            {% include recs/recs-sidemenu.html %}
+    <div class="banner">
+        <span style="font-size: larger; font-weight: bold">We've moved!
+            The HGVS Nomenclature is now at <a
+                href="https://hgvs-nomenclature.org/">https://hgvs-nomenclature.org/</a>.</span>
+        <br />
+        This site contains an archive of varnomen.hgvs.org and is no longer maintained.
+    </div>
 
-            {% if page.last-modified %}
-                <div class="last-modified pull-right">
-                    Last modified: {{ page.last-modified }}
-                </div>
-            {% endif %}
+    <div class="container">
+        {% include recs/recs-sidemenu.html %}
 
-            {% include recs/recs-main.html %}
+        {% if page.last-modified %}
+        <div class="last-modified pull-right">
+            Last modified: {{ page.last-modified }}
         </div>
+        {% endif %}
 
-        {% include footer.html %}
+        {% include recs/recs-main.html %}
+    </div>
 
-    </body>
+    {% include footer.html %}
+
+</body>
 
 </html>

--- a/css/main.css
+++ b/css/main.css
@@ -1,3 +1,15 @@
+.banner {
+    background-color: #fbb;
+    border-radius: 10px;
+    border: 3px solid;
+    color: #f00;
+    font-size: large;
+    margin: 10px auto;
+    padding: 20px;
+    text-align: center;
+    width: 80%;
+}
+
 :target:before {
     content: "";
     display: block;
@@ -6,7 +18,7 @@
 }   
 
 body {
-    padding-top: 110px;
+    padding-top: 50px !important;
     height: 100%;
 }
 


### PR DESCRIPTION
*important* don't merge until the CNAME is preserved
Also, leave redirect disabled for now.

The goal is to get the two repos as close as possible, differing only by CNAME and _config.yml (i.e., redirection) so that future cleanup is easier/clearer.